### PR TITLE
[sail] Deprecate old options

### DIFF
--- a/recipes/sail/all/conanfile.py
+++ b/recipes/sail/all/conanfile.py
@@ -23,6 +23,14 @@ class SAILConan(ConanFile):
         "with_medium_priority_codecs": [True, False],
         "with_low_priority_codecs": [True, False],
         "with_lowest_priority_codecs": [True, False],
+        "with_avif": [True, False, "deprecated"],
+        "with_gif": [True, False, "deprecated"],
+        "with_jpeg2000": [True, False, "deprecated"],
+        "with_jpeg": ["libjpeg", "libjpeg-turbo", False, "deprecated"],
+        "with_png": [True, False, "deprecated"],
+        "with_tiff": [True, False, "deprecated"],
+        "with_webp": [True, False, "deprecated"],
+
     }
     default_options = {
         "shared": False,
@@ -33,6 +41,13 @@ class SAILConan(ConanFile):
         "with_medium_priority_codecs": True,
         "with_low_priority_codecs": True,
         "with_lowest_priority_codecs": True,
+        "with_avif": "deprecated",
+        "with_gif": "deprecated",
+        "with_jpeg2000": "deprecated",
+        "with_jpeg": "deprecated",
+        "with_png": "deprecated",
+        "with_tiff": "deprecated",
+        "with_webp": "deprecated",
     }
 
     def export_sources(self):
@@ -60,6 +75,20 @@ class SAILConan(ConanFile):
             #   - https://github.com/conan-io/conan-center-index/pull/18812
             # self.requires("libjxl/0.6.1")
             self.requires("libwebp/1.3.2")
+
+    def package_id(self):
+        del self.info.options.with_avif
+        del self.info.options.with_gif
+        del self.info.options.with_jpeg2000
+        del self.info.options.with_jpeg
+        del self.info.options.with_png
+        del self.info.options.with_tiff
+        del self.info.options.with_webp
+
+    def validate(self):
+        for option_name in ["with_avif", "with_gif", "with_jpeg2000", "with_jpeg", "with_png", "with_tiff", "with_webp"]:
+            if getattr(self.options, option_name) != "deprecated":
+                self.output.warning(f"{self.ref}:{option_name} option is deprecated, please, use 'with_xxx_priority_codecs' instead.")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/sail/all/conanfile.py
+++ b/recipes/sail/all/conanfile.py
@@ -49,6 +49,21 @@ class SAILConan(ConanFile):
         "with_tiff": "deprecated",
         "with_webp": "deprecated",
     }
+    options_description = {
+        "with_avif": "Deprecated",
+        "with_gif": "Deprecated",
+        "with_jpeg2000": "Deprecated",
+        "with_jpeg": "Deprecated",
+        "with_png": "Deprecated",
+        "with_tiff": "Deprecated",
+        "with_webp": "Deprecated",
+        "with_highest_priority_codecs": "Enable highest priority codecs",
+        "with_high_priority_codecs": "Enable high priority codecs",
+        "with_medium_priority_codecs": "Enable medium priority codecs",
+        "with_low_priority_codecs": "Enable low priority codecs",
+        "with_lowest_priority_codecs": "Enable lowest priority codecs",
+    }
+
 
     def export_sources(self):
         export_conandata_patches(self)


### PR DESCRIPTION
This is a follow-up over the PR https://github.com/conan-io/conan-center-index/pull/20788. Some important points:

- In ConanCenterIndex we avoid removing an option directly, it should be deprecated first, so users will be warned about the breaking change. It's documented here: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#can-i-remove-an-option-from-a-recipe
- The `with_xxx_priority_codecs` is hard to figure out what dependencies are installed with it, so I added [options_description](https://docs.conan.io/2/reference/conanfile/attributes.html#options-description) to illustrate what each option should be, but to be honest, I don't know what should the option description. 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
